### PR TITLE
fix(PlayCommand): handle when lavalink node not available

### DIFF
--- a/src/Commands/Music/PlayCommand.js
+++ b/src/Commands/Music/PlayCommand.js
@@ -25,11 +25,8 @@ module.exports = class PlayCommand extends Command {
 
   async exec(msg, { query }) {
     try {
-      const nodes = this.client.erela.nodes.filter(node => node.connected);
-      switch (nodes.size) {
-        case 0:
-          return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | No nodes are currently connected.')] });
-      }
+      const node = this.client.erela.leastUsedNodes.first();
+      if (!node || !node.connected) return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | No nodes are currently connected.')] });
       const MusicTracks = await this.client.erela.search(query, msg.author);
       if (MusicTracks.loadType === 'NO_MATCHES') return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | No result found.')] });
       if (MusicTracks.loadType === 'LOAD_FAILED') return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | An error occured when loading the track.')] });

--- a/src/Commands/Music/PlayCommand.js
+++ b/src/Commands/Music/PlayCommand.js
@@ -25,6 +25,11 @@ module.exports = class PlayCommand extends Command {
 
   async exec(msg, { query }) {
     try {
+      const nodes = this.client.erela.nodes.filter(node => node.connected);
+      switch (nodes.size) {
+        case 0:
+          return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | No nodes are currently connected.')] });
+      }
       const MusicTracks = await this.client.erela.search(query, msg.author);
       if (MusicTracks.loadType === 'NO_MATCHES') return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | No result found.')] });
       if (MusicTracks.loadType === 'LOAD_FAILED') return msg.channel.send({ embeds: [CreateEmbed('warn', '⛔ | An error occured when loading the track.')] });


### PR DESCRIPTION
Better checking first instead just throwing an error

Especially for Free lavalink server always 'on-off' everyday eg: replit. 
It's raising `Unable to connect after 5 attempts.` and just throw error
